### PR TITLE
feat: containerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.16.4 as base
+
+ENV GO111MODULE=on
+WORKDIR /app
+
+COPY go.mod .
+COPY go.sum .
+
+RUN go mod download
+
+COPY . .
+
+FROM base AS builder
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build .
+
+FROM alpine:3.12
+COPY --from=builder /app/docsonnet /usr/local/bin
+
+ENTRYPOINT ["docsonnet"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN go mod download
 COPY . .
 
 FROM base AS builder
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build . -ldflags='-s -w -extldflags "-static"'
 
 FROM alpine:3.12
 COPY --from=builder /app/docsonnet /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN go mod download
 COPY . .
 
 FROM base AS builder
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build . -ldflags='-s -w -extldflags "-static"'
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags='-s -w -extldflags "-static"' .
 
 FROM alpine:3.12
 COPY --from=builder /app/docsonnet /usr/local/bin

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: build test push push-image
+
+IMAGE_NAME ?= docsonnet
+IMAGE_PREFIX ?= jsonnet-libs
+IMAGE_TAG ?= 0.0.1
+
+build:
+	docker build -t $(IMAGE_PREFIX)/$(IMAGE_NAME):$(IMAGE_TAG) .
+
+test: build
+
+push: build test push-image
+
+push-image:
+	docker push $(IMAGE_PREFIX)/$(IMAGE_NAME):$(IMAGE_TAG)
+	docker push $(IMAGE_PREFIX)/$(IMAGE_NAME):latest

--- a/doc-util/README.md
+++ b/doc-util/README.md
@@ -5,7 +5,7 @@ permalink: /
 # package d
 
 ```jsonnet
-local d = import "github.com/sh0rez/docsonnet/doc-util"
+local d = import "github.com/jsonnet-libs/docsonnet/doc-util"
 ```
 
 `doc-util` provides a Jsonnet interface for `docsonnet`,

--- a/doc-util/main.libsonnet
+++ b/doc-util/main.libsonnet
@@ -3,7 +3,7 @@
 
   '#': d.pkg(
     name='d',
-    url='github.com/sh0rez/docsonnet/doc-util',
+    url='github.com/jsonnet-libs/docsonnet/doc-util',
     help=|||
       `doc-util` provides a Jsonnet interface for `docsonnet`,
        a Jsonnet API doc generator that uses structured data instead of comments.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/sh0rez/docsonnet
+module github.com/jsonnet-libs/docsonnet
 
-go 1.14
+go 1.16
 
 require (
 	github.com/go-clix/cli v0.1.2-0.20200502172020-b8f4629e879a

--- a/go.sum
+++ b/go.sum
@@ -39,13 +39,10 @@ golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.7 h1:VUgggvou5XRW9mHwD/yXxIYSMtY0zoKQf/v226p2nyo=

--- a/main.go
+++ b/main.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/go-clix/cli"
 
-	"github.com/sh0rez/docsonnet/pkg/docsonnet"
-	"github.com/sh0rez/docsonnet/pkg/render"
+	"github.com/jsonnet-libs/docsonnet/pkg/docsonnet"
+	"github.com/jsonnet-libs/docsonnet/pkg/render"
 )
 
 func main() {

--- a/pkg/docsonnet/load.go
+++ b/pkg/docsonnet/load.go
@@ -96,7 +96,7 @@ func newImporter(paths []string) (*importer, error) {
 
 var docUtilPaths = []string{
 	"doc-util/main.libsonnet",
-	"github.com/sh0rez/docsonnet/doc-util/main.libsonnet",
+	"github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet",
 }
 
 func (i *importer) Import(importedFrom, importedPath string) (contents jsonnet.Contents, foundAt string, err error) {

--- a/pkg/render/fs.go
+++ b/pkg/render/fs.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/sh0rez/docsonnet/pkg/docsonnet"
+	"github.com/jsonnet-libs/docsonnet/pkg/docsonnet"
 )
 
 func To(pkg docsonnet.Package, dir string, opts Opts) (int, error) {

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 
 	"github.com/google/go-jsonnet/formatter"
-	"github.com/sh0rez/docsonnet/pkg/docsonnet"
-	"github.com/sh0rez/docsonnet/pkg/md"
-	"github.com/sh0rez/docsonnet/pkg/slug"
+	"github.com/jsonnet-libs/docsonnet/pkg/docsonnet"
+	"github.com/jsonnet-libs/docsonnet/pkg/md"
+	"github.com/jsonnet-libs/docsonnet/pkg/slug"
 )
 
 type Opts struct {

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -3,7 +3,7 @@ package render
 import (
 	"testing"
 
-	"github.com/sh0rez/docsonnet/pkg/docsonnet"
+	"github.com/jsonnet-libs/docsonnet/pkg/docsonnet"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
- replaces `sh0rez` with `jsonnet-libs`
- builds with Go 1.16
- adds Dockerfile and Makefile to build a container

It would be useful to have this containerized so we can use it in k8s-gen without having to build it there again.