### PR TITLE
add github action to push image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       -

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,7 +28,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: user/app:latest
+          tags: jsonnetlibs/docsonnet:latest
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,34 @@
+# https://github.com/marketplace/actions/build-and-push-docker-images#git-context
+name: ci
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: user/app:latest
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,14 @@
 # https://github.com/marketplace/actions/build-and-push-docker-images#git-context
 name: ci
 
+
 on:
   push:
+    branches:
+      - 'master'
+    tags:
+      - 'v*'
+  pull_request:
     branches:
       - 'master'
 
@@ -17,6 +23,17 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: jsonnetlibs/docsonnet
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+      -
         name: Login to DockerHub
         uses: docker/login-action@v1 
         with:
@@ -27,8 +44,10 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          push: true
-          tags: jsonnetlibs/docsonnet:latest
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.4 as base
+FROM --platform=$BUILDPLATFORM golang:1.16.4 as base
 
 ENV GO111MODULE=on
 WORKDIR /app
@@ -11,7 +11,10 @@ RUN go mod download
 COPY . .
 
 FROM base AS builder
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags='-s -w -extldflags "-static"' .
+
+ARG TARGETPLATFORM
+
+RUN CGO_ENABLED=0 go build -ldflags='-s -w -extldflags "-static"' .
 
 FROM alpine:3.12
 COPY --from=builder /app/docsonnet /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,7 @@ COPY . .
 
 FROM base AS builder
 
-ARG TARGETPLATFORM
-
+ENV GOARCH=$TARGETARCH
 RUN CGO_ENABLED=0 go build -ldflags='-s -w -extldflags "-static"' .
 
 FROM alpine:3.12

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 .PHONY: build test push push-image
 
 IMAGE_NAME ?= docsonnet
-IMAGE_PREFIX ?= jsonnet-libs
+IMAGE_PREFIX ?= jsonnetlibs
 IMAGE_TAG ?= 0.0.1
 
 build:
-	docker build -t $(IMAGE_PREFIX)/$(IMAGE_NAME):$(IMAGE_TAG) .
+	docker buildx build -t $(IMAGE_PREFIX)/$(IMAGE_NAME):$(IMAGE_TAG) .
 
 test: build
 


### PR DESCRIPTION
I've made an org/repo for this: https://hub.docker.com/r/jsonnetlibs/docsonnet

The credentials on the repo is an api key on my account.

This leverages `docker buildx` through this github action:
https://github.com/marketplace/actions/build-and-push-docker-images

Also sets the version tags based with the metadata action:
https://github.com/docker/metadata-action