### PR TITLE
Extend render template with common usage & install instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,5 +16,6 @@ push-image:
 	docker push $(IMAGE_PREFIX)/$(IMAGE_NAME):latest
 
 docs:
-	jsonnet -J doc-util -S -c -m doc-util/ doc-util/docs.jsonnet
+	jsonnet -S -c -m doc-util/ \
+		-e "(import 'doc-util/main.libsonnet').render(import 'doc-util/main.libsonnet')"
 

--- a/doc-util/README.md
+++ b/doc-util/README.md
@@ -3,14 +3,16 @@
 `doc-util` provides a Jsonnet interface for `docsonnet`,
  a Jsonnet API doc generator that uses structured data instead of comments.
 
-Install:
+## Install
 
-`$ jb install github.com/jsonnet-libs/docsonnet/doc-util@master`
+```
+jb install github.com/jsonnet-libs/docsonnet/doc-util@master
+```
 
-Usage:
+## Usage
 
 ```jsonnet
-local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/doc-util/main.libsonnet';
+local d = import "github.com/jsonnet-libs/docsonnet/doc-util/doc-util/main.libsonnet"
 ```
 
 ## Index
@@ -18,7 +20,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/doc-util/main.libso
 * [`fn arg(name, type, default)`](#fn-arg)
 * [`fn fn(help, args)`](#fn-fn)
 * [`fn obj(help, fields)`](#fn-obj)
-* [`fn pkg(name, url, help, filename='', tag=master)`](#fn-pkg)
+* [`fn pkg(name, url, help, filename='', version=master)`](#fn-pkg)
 * [`fn render(obj)`](#fn-render)
 * [`fn val(type, help, default)`](#fn-val)
 * [`obj argument`](#obj-argument)
@@ -34,7 +36,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/doc-util/main.libso
   * [`fn new(type, help, default)`](#fn-valuenew)
 * [`obj T`](#obj-t)
 * [`obj package`](#obj-package)
-  * [`fn new(name, url, help, filename='', tag=master)`](#fn-packagenew)
+  * [`fn new(name, url, help, filename='', version=master)`](#fn-packagenew)
 
 ## Fields
 
@@ -65,7 +67,7 @@ obj(help, fields)
 ### fn pkg
 
 ```ts
-pkg(name, url, help, filename='', tag=master)
+pkg(name, url, help, filename='', version=master)
 ```
 
 `new` is a shorthand for `package.new`
@@ -186,7 +188,7 @@ new creates a new object of given type, optionally with description and default 
 #### fn package.new
 
 ```ts
-new(name, url, help, filename='', tag=master)
+new(name, url, help, filename='', version=master)
 ```
 
 `new` creates a new package
@@ -197,5 +199,5 @@ Arguments:
 * source `url` for jsonnet-bundler and the import
 * `help` text
 * `filename` for the import, defaults to blank for backward compatibility
-* `tag` for jsonnet-bundler install, defaults to `master` just like jsonnet-bundler
+* `version` for jsonnet-bundler install, defaults to `master` just like jsonnet-bundler
 

--- a/doc-util/README.md
+++ b/doc-util/README.md
@@ -1,19 +1,25 @@
 # package d
 
-```jsonnet
-local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
-```
-
 `doc-util` provides a Jsonnet interface for `docsonnet`,
  a Jsonnet API doc generator that uses structured data instead of comments.
+
+Install:
+
+`$ jb install github.com/jsonnet-libs/docsonnet/doc-util@master`
+
+Usage:
+
+```jsonnet
+local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/doc-util/main.libsonnet';
+```
 
 ## Index
 
 * [`fn arg(name, type, default)`](#fn-arg)
 * [`fn fn(help, args)`](#fn-fn)
 * [`fn obj(help, fields)`](#fn-obj)
-* [`fn pkg(name, url, help)`](#fn-pkg)
-* [`fn render(obj, filename)`](#fn-render)
+* [`fn pkg(name, url, help, filename='', tag=master)`](#fn-pkg)
+* [`fn render(obj)`](#fn-render)
 * [`fn val(type, help, default)`](#fn-val)
 * [`obj argument`](#obj-argument)
   * [`fn new(name, type, default)`](#fn-argumentnew)
@@ -28,7 +34,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
   * [`fn new(type, help, default)`](#fn-valuenew)
 * [`obj T`](#obj-t)
 * [`obj package`](#obj-package)
-  * [`fn new(name, url, help)`](#fn-packagenew)
+  * [`fn new(name, url, help, filename='', tag=master)`](#fn-packagenew)
 
 ## Fields
 
@@ -59,7 +65,7 @@ obj(help, fields)
 ### fn pkg
 
 ```ts
-pkg(name, url, help)
+pkg(name, url, help, filename='', tag=master)
 ```
 
 `new` is a shorthand for `package.new`
@@ -67,7 +73,7 @@ pkg(name, url, help)
 ### fn render
 
 ```ts
-render(obj, filename)
+render(obj)
 ```
 
 `render` converts the docstrings to human readable Markdown files.
@@ -76,7 +82,7 @@ Usage:
 
 ```jsonnet
 // docs.jsonnet
-d.render(import 'main.libsonnet', 'main.libsonnet')
+d.render(import 'main.libsonnet')
 ```
 
 Call with: `jsonnet -S -c -m docs/ docs.jsonnet`
@@ -180,7 +186,16 @@ new creates a new object of given type, optionally with description and default 
 #### fn package.new
 
 ```ts
-new(name, url, help)
+new(name, url, help, filename='', tag=master)
 ```
 
-new creates a new package with given `name`, `import` URL and `help` text
+`new` creates a new package
+
+Arguments:
+
+* given `name`
+* source `url` for jsonnet-bundler and the import
+* `help` text
+* `filename` for the import, defaults to blank for backward compatibility
+* `tag` for jsonnet-bundler install, defaults to `master` just like jsonnet-bundler
+

--- a/doc-util/README.md
+++ b/doc-util/README.md
@@ -3,6 +3,7 @@
 `doc-util` provides a Jsonnet interface for `docsonnet`,
  a Jsonnet API doc generator that uses structured data instead of comments.
 
+
 ## Install
 
 ```

--- a/doc-util/README.md
+++ b/doc-util/README.md
@@ -21,7 +21,7 @@ local d = import "github.com/jsonnet-libs/docsonnet/doc-util/doc-util/main.libso
 * [`fn arg(name, type, default)`](#fn-arg)
 * [`fn fn(help, args)`](#fn-fn)
 * [`fn obj(help, fields)`](#fn-obj)
-* [`fn pkg(name, url, help, filename='', version=master)`](#fn-pkg)
+* [`fn pkg(name, url, help, filename='', version='master')`](#fn-pkg)
 * [`fn render(obj)`](#fn-render)
 * [`fn val(type, help, default)`](#fn-val)
 * [`obj argument`](#obj-argument)
@@ -37,7 +37,7 @@ local d = import "github.com/jsonnet-libs/docsonnet/doc-util/doc-util/main.libso
   * [`fn new(type, help, default)`](#fn-valuenew)
 * [`obj T`](#obj-t)
 * [`obj package`](#obj-package)
-  * [`fn new(name, url, help, filename='', version=master)`](#fn-packagenew)
+  * [`fn new(name, url, help, filename='', version='master')`](#fn-packagenew)
 
 ## Fields
 
@@ -68,7 +68,7 @@ obj(help, fields)
 ### fn pkg
 
 ```ts
-pkg(name, url, help, filename='', version=master)
+pkg(name, url, help, filename='', version='master')
 ```
 
 `new` is a shorthand for `package.new`
@@ -189,7 +189,7 @@ new creates a new object of given type, optionally with description and default 
 #### fn package.new
 
 ```ts
-new(name, url, help, filename='', version=master)
+new(name, url, help, filename='', version='master')
 ```
 
 `new` creates a new package

--- a/doc-util/docs.jsonnet
+++ b/doc-util/docs.jsonnet
@@ -1,3 +1,0 @@
-local d = import './main.libsonnet';
-
-d.render(import 'main.libsonnet', 'main.libsonnet')

--- a/doc-util/main.libsonnet
+++ b/doc-util/main.libsonnet
@@ -21,23 +21,40 @@
       * source `url` for jsonnet-bundler and the import
       * `help` text
       * `filename` for the import, defaults to blank for backward compatibility
-      * `tag` for jsonnet-bundler install, defaults to `master` just like jsonnet-bundler
+      * `version` for jsonnet-bundler install, defaults to `master` just like jsonnet-bundler
     |||, [
       d.arg('name', d.T.string),
       d.arg('url', d.T.string),
       d.arg('help', d.T.string),
       d.arg('filename', d.T.string, ''),
-      d.arg('tag', d.T.string, 'master'),
+      d.arg('version', d.T.string, 'master'),
     ]),
-    new(name, url, help, filename='', tag='master'):: {
-      name: name,
-      help: help,
+    new(name, url, help, filename='', version='master')::
+      {
+        name: name,
+        help: help,
+        'import':
+          if filename != ''
+          then url + '/' + filename
+          else url,
+        url: url,
+        filename: filename,
+        version: version,
 
-      url: url,
-      filename: filename,
-      tag: tag,
+      }
+      + self.withInstallTemplate(
+        'jb install %(url)s@%(version)s'
+      )
+      + self.withUsageTemplate(
+        'local %(name)s = import "%(import)s"'
+      ),
 
-      'import': url + (if filename != '' then '/' + filename else ''),
+    withUsageTemplate(template):: {
+      usageTemplate: template,
+    },
+
+    withInstallTemplate(template):: {
+      installTemplate: template,
     },
   },
 

--- a/doc-util/main.libsonnet
+++ b/doc-util/main.libsonnet
@@ -7,15 +7,37 @@
     help=|||
       `doc-util` provides a Jsonnet interface for `docsonnet`,
        a Jsonnet API doc generator that uses structured data instead of comments.
-    |||
+    |||,
+    filename=std.thisFile,
   ),
 
   package:: {
-    '#new':: d.fn('new creates a new package with given `name`, `import` URL and `help` text', [d.arg('name', d.T.string), d.arg('url', d.T.string), d.arg('help', d.T.string)]),
-    new(name, url, help):: {
+    '#new':: d.fn(|||
+      `new` creates a new package
+
+      Arguments:
+
+      * given `name`
+      * source `url` for jsonnet-bundler and the import
+      * `help` text
+      * `filename` for the import, defaults to blank for backward compatibility
+      * `tag` for jsonnet-bundler install, defaults to `master` just like jsonnet-bundler
+    |||, [
+      d.arg('name', d.T.string),
+      d.arg('url', d.T.string),
+      d.arg('help', d.T.string),
+      d.arg('filename', d.T.string, ''),
+      d.arg('tag', d.T.string, 'master'),
+    ]),
+    new(name, url, help, filename='', tag='master'):: {
       name: name,
-      'import': url,
       help: help,
+
+      url: url,
+      filename: filename,
+      tag: tag,
+
+      'import': url + (if filename != '' then '/' + filename else ''),
     },
   },
 
@@ -125,14 +147,13 @@
 
       ```jsonnet
       // docs.jsonnet
-      d.render(import 'main.libsonnet', 'main.libsonnet')
+      d.render(import 'main.libsonnet')
       ```
 
       Call with: `jsonnet -S -c -m docs/ docs.jsonnet`
     |||,
     args=[
       d.arg('obj', d.T.object),
-      d.arg('filename', d.T.string),
     ]
   ),
   render:: (import './render.libsonnet').render,

--- a/doc-util/render.libsonnet
+++ b/doc-util/render.libsonnet
@@ -208,16 +208,17 @@
         ||| % doc
         + (if 'installTemplate' in doc
            then |||
+
              ## Install
 
              ```
              %(install)s
              ```
-
            ||| % doc.installTemplate % doc
            else '')
         + (if 'usageTemplate' in doc
            then |||
+
              ## Usage
 
              ```jsonnet

--- a/doc-util/render.libsonnet
+++ b/doc-util/render.libsonnet
@@ -182,7 +182,11 @@
 
       args: std.join(', ', [
         if arg.default != null
-        then arg.name + '=' + (if arg.default == '' then "''" else arg.default)
+        then arg.name + '=' + (
+          if arg.type == 'string'
+          then "'%s'" % arg.default
+          else std.toString(arg.default)
+        )
         else arg.name
         for arg in self.doc.args
       ]),

--- a/doc-util/render.libsonnet
+++ b/doc-util/render.libsonnet
@@ -206,21 +206,25 @@
         |||
           %(help)s
         ||| % doc
-        + (if root != null
+        + (if 'installTemplate' in doc
            then |||
-             Install:
+             ## Install
 
-             `$ jb install %(url)s@%(tag)s`
+             ```
+             %(install)s
+             ```
 
-           ||| % doc
+           ||| % doc.installTemplate % doc
            else '')
-        + |||
-          Usage:
+        + (if 'usageTemplate' in doc
+           then |||
+             ## Usage
 
-          ```jsonnet
-          local %(name)s = import '%(import)s';
-          ```
-        ||| % doc,
+             ```jsonnet
+             %(usage)s
+             ```
+           ||| % doc.usageTemplate % doc
+           else ''),
     },
   },
 


### PR DESCRIPTION
This PR adds install instructions with jsonnet-bundler to the jsonnet renderer.

I took the opportunity to give the author the ability to extend the template for the install and usage instructions, this way the documentation can be enriched with more useful example while keeping a generic structure.

I have not backported these into the Golang binary but kept it backwards compatible.

