### PR TITLE
fix(doc-util): print info message when docstring can't get parsed

### DIFF
--- a/doc-util/render.libsonnet
+++ b/doc-util/render.libsonnet
@@ -244,11 +244,20 @@
           (depth == 0)
         )
 
+
         // Field definition
         else if std.startsWith(key, '#')
         then (
           local realKey = key[1:];
-          if 'value' in obj[key]
+
+          if !std.isObject(obj[key])
+          then
+            std.trace(
+              'INFO: docstring "%s" cannot be parsed, ignored while rendering.' % key,
+              {}
+            )
+
+          else if 'value' in obj[key]
           then {
             values+: [root.sections.value(
               key,
@@ -272,7 +281,11 @@
               depth
             )],
           }
-          else {}
+          else
+            std.trace(
+              'INFO: docstring "%s" cannot be parsed, ignored while rendering.' % key,
+              {}
+            )
         )
 
         // subPackage definition


### PR DESCRIPTION
If the docstring is not an object, we can assume it is not valid.

For invalid docstrings, we'll yield an INFO message with `std.trace` to make it easier to
debug.

This was brought up in https://github.com/jsonnet-libs/docsonnet/issues/29#issuecomment-1233605650