### PR TITLE
feat: add newSub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ release:
 	goreleaser release --rm-dist
 
 docs:
-	jsonnet -S -c -m doc-util/ \
-		-e "(import 'doc-util/main.libsonnet').render(import 'doc-util/main.libsonnet')"
+	cd doc-util && \
+	jsonnet -S -c -m . \
+		-e "(import './main.libsonnet').render(import './main.libsonnet')"
 

--- a/doc-util/README.md
+++ b/doc-util/README.md
@@ -38,6 +38,7 @@ local d = import "github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet"
 * [`obj T`](#obj-t)
 * [`obj package`](#obj-package)
   * [`fn new(name, url, help, filename='', version='master')`](#fn-packagenew)
+  * [`fn newSub(name, help)`](#fn-packagenewsub)
 
 ## Fields
 
@@ -201,4 +202,18 @@ Arguments:
 * `help` text
 * `filename` for the import, defaults to blank for backward compatibility
 * `version` for jsonnet-bundler install, defaults to `master` just like jsonnet-bundler
+
+
+#### fn package.newSub
+
+```ts
+newSub(name, help)
+```
+
+`newSub` creates a package without the preconfigured install/usage templates.
+
+Arguments:
+
+* given `name`
+* `help` text
 

--- a/doc-util/main.libsonnet
+++ b/doc-util/main.libsonnet
@@ -49,6 +49,23 @@
         'local %(name)s = import "%(import)s"'
       ),
 
+    '#newSub':: d.fn(|||
+      `newSub` creates a package without the preconfigured install/usage templates.
+
+      Arguments:
+
+      * given `name`
+      * `help` text
+    |||, [
+      d.arg('name', d.T.string),
+      d.arg('help', d.T.string),
+    ]),
+    newSub(name, help)::
+      {
+        name: name,
+        help: help,
+      },
+
     withUsageTemplate(template):: {
       usageTemplate: template,
     },


### PR DESCRIPTION
When working on more complex projects, I often feel like a need a more 'simple' package
layout. This new function just keeps the bare minimum to render a package without its
templates.