### PR TITLE
fix(render): remove 'package' prefix

### DIFF
--- a/doc-util/render.libsonnet
+++ b/doc-util/render.libsonnet
@@ -3,7 +3,7 @@
 
   templates: {
     package: |||
-      # package %(name)s
+      # %(name)s
 
       %(content)s
     |||,


### PR DESCRIPTION
This prefix doesn't have an extra value, just clutters it up.