### PR TITLE
fix(doc-util): use manifestJsonEx to render default/enum

### DIFF
--- a/doc-util/README.md
+++ b/doc-util/README.md
@@ -1,4 +1,4 @@
-# package d
+# doc-util
 
 `doc-util` provides a Jsonnet interface for `docsonnet`,
  a Jsonnet API doc generator that uses structured data instead of comments.
@@ -21,7 +21,7 @@ local d = import "github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet"
 * [`fn arg(name, type, default, enums)`](#fn-arg)
 * [`fn fn(help, args)`](#fn-fn)
 * [`fn obj(help, fields)`](#fn-obj)
-* [`fn pkg(name, url, help, filename='', version='master')`](#fn-pkg)
+* [`fn pkg(name, url, help, filename="", version="master")`](#fn-pkg)
 * [`fn render(obj)`](#fn-render)
 * [`fn val(type, help, default)`](#fn-val)
 * [`obj argument`](#obj-argument)
@@ -37,7 +37,7 @@ local d = import "github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet"
   * [`fn new(type, help, default)`](#fn-valuenew)
 * [`obj T`](#obj-t)
 * [`obj package`](#obj-package)
-  * [`fn new(name, url, help, filename='', version='master')`](#fn-packagenew)
+  * [`fn new(name, url, help, filename="", version="master")`](#fn-packagenew)
   * [`fn newSub(name, help)`](#fn-packagenewsub)
 
 ## Fields
@@ -69,7 +69,7 @@ obj(help, fields)
 ### fn pkg
 
 ```ts
-pkg(name, url, help, filename='', version='master')
+pkg(name, url, help, filename="", version="master")
 ```
 
 `new` is a shorthand for `package.new`
@@ -202,7 +202,7 @@ new creates a new object of given type, optionally with description and default 
 #### fn package.new
 
 ```ts
-new(name, url, help, filename='', version='master')
+new(name, url, help, filename="", version="master")
 ```
 
 `new` creates a new package

--- a/doc-util/main.libsonnet
+++ b/doc-util/main.libsonnet
@@ -1,15 +1,19 @@
 {
   local d = self,
 
-  '#': d.pkg(
-    name='d',
-    url='github.com/jsonnet-libs/docsonnet/doc-util',
-    help=|||
-      `doc-util` provides a Jsonnet interface for `docsonnet`,
-       a Jsonnet API doc generator that uses structured data instead of comments.
-    |||,
-    filename=std.thisFile,
-  ),
+  '#':
+    d.pkg(
+      name='doc-util',
+      url='github.com/jsonnet-libs/docsonnet/doc-util',
+      help=|||
+        `doc-util` provides a Jsonnet interface for `docsonnet`,
+         a Jsonnet API doc generator that uses structured data instead of comments.
+      |||,
+      filename=std.thisFile,
+    )
+    + d.package.withUsageTemplate(
+      'local d = import "%(import)s"'
+    ),
 
   package:: {
     '#new':: d.fn(|||

--- a/doc-util/render.libsonnet
+++ b/doc-util/render.libsonnet
@@ -194,11 +194,10 @@
 
       args: std.join(', ', [
         if arg.default != null
-        then arg.name + '=' + (
-          if arg.type == 'string'
-          then "'%s'" % arg.default
-          else std.toString(arg.default)
-        )
+        then std.join('=', [
+          arg.name,
+          std.manifestJsonEx(arg.default, '', ''),
+        ])
         else arg.name
         for arg in self.doc.args
       ]),
@@ -206,12 +205,10 @@
       enums: std.join('', [
         if arg.enums != null
         then '\n\nAccepted values for `%s` are ' % arg.name
-             + (
-               std.join(', ', [
-                 std.toString(item)
-                 for item in arg.enums
-               ])
-             )
+             + std.join(', ', [
+               std.manifestJsonEx(item, '', '')
+               for item in arg.enums
+             ])
         else ''
         for arg in self.doc.args
       ]),


### PR DESCRIPTION
Unlike `std.toString`, `std.manifestJsonEx` returns quite consistent results for various objects.

Also, this behaves consistently between go-jsonnet and jrsonnet, from https://github.com/CertainLach/jrsonnet/issues/108: 

> \\ go-jsonnet
> ❯ nix run nixpkgs#go-jsonnet -- -e "std.manifestJson(0.97)"
> "0.97"
> ❯ nix run nixpkgs#go-jsonnet -- -e "std.toString(0.97)"
> "0.96999999999999997"
> ❯ nix run nixpkgs#go-jsonnet -- -e 0.97
> 0.96999999999999997
> 
> ...
> \\ jrsonnet
> ❯ cargo run -- -e "std.manifestJson(0.97)"
> "0.97"
> ❯ cargo run -- -e "std.toString(0.97)"
> "0.97"
> ❯ cargo run -- -e 0.97
> 0.97