### PR TITLE
fix(render): don't render separate index if has sub packages

### DIFF
--- a/doc-util/render.libsonnet
+++ b/doc-util/render.libsonnet
@@ -373,7 +373,7 @@
     (
       if std.length(prefixes) == 0
       then {
-        [path + 'README.md']: root.renderPackage(package),
+        [path + 'README.md']: root.renderPackage(package, package.name + '/'),
       }
       else if std.length(package.subPackages) > 0
       then {


### PR DESCRIPTION
When rendering sub-packages, the page about the package and the index were rendered
separately. This places the package doc outside the sub directory making it harder to
navigate. This became clear to me when rendering the docs for Grafonnet, which has several
layers of sub-packages.

This PR places the package doc in the index of the sub directory.