### PR TITLE
refactor: render engine

### DIFF
--- a/doc-util/README.md
+++ b/doc-util/README.md
@@ -16,6 +16,7 @@ jb install github.com/jsonnet-libs/docsonnet/doc-util@master
 local d = import "github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet"
 ```
 
+
 ## Index
 
 * [`fn arg(name, type, default, enums)`](#fn-arg)

--- a/doc-util/README.md
+++ b/doc-util/README.md
@@ -3,7 +3,6 @@
 `doc-util` provides a Jsonnet interface for `docsonnet`,
  a Jsonnet API doc generator that uses structured data instead of comments.
 
-
 ## Install
 
 ```
@@ -45,7 +44,7 @@ local d = import "github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet"
 
 ### fn arg
 
-```ts
+```jsonnet
 arg(name, type, default, enums)
 ```
 
@@ -53,7 +52,7 @@ arg(name, type, default, enums)
 
 ### fn fn
 
-```ts
+```jsonnet
 fn(help, args)
 ```
 
@@ -61,7 +60,7 @@ fn(help, args)
 
 ### fn obj
 
-```ts
+```jsonnet
 obj(help, fields)
 ```
 
@@ -69,7 +68,7 @@ obj(help, fields)
 
 ### fn pkg
 
-```ts
+```jsonnet
 pkg(name, url, help, filename="", version="master")
 ```
 
@@ -77,7 +76,7 @@ pkg(name, url, help, filename="", version="master")
 
 ### fn render
 
-```ts
+```jsonnet
 render(obj)
 ```
 
@@ -95,7 +94,7 @@ Call with: `jsonnet -S -c -m docs/ docs.jsonnet`
 
 ### fn val
 
-```ts
+```jsonnet
 val(type, help, default)
 ```
 
@@ -107,7 +106,7 @@ Utilities for creating function arguments
 
 #### fn argument.new
 
-```ts
+```jsonnet
 new(name, type, default, enums)
 ```
 
@@ -131,7 +130,7 @@ Utilities for documenting Jsonnet methods (functions of objects)
 
 #### fn func.new
 
-```ts
+```jsonnet
 new(help, args)
 ```
 
@@ -139,7 +138,7 @@ new creates a new function, optionally with description and arguments
 
 #### fn func.withArgs
 
-```ts
+```jsonnet
 withArgs(args)
 ```
 
@@ -147,7 +146,7 @@ The `withArgs` modifier overrides the arguments of that function
 
 #### fn func.withHelp
 
-```ts
+```jsonnet
 withHelp(help)
 ```
 
@@ -159,7 +158,7 @@ Utilities for documenting Jsonnet objects (`{ }`).
 
 #### fn object.new
 
-```ts
+```jsonnet
 new(help, fields)
 ```
 
@@ -167,7 +166,7 @@ new creates a new object, optionally with description and fields
 
 #### fn object.withFields
 
-```ts
+```jsonnet
 withFields(fields)
 ```
 
@@ -179,14 +178,13 @@ Utilities for documenting plain Jsonnet values (primitives)
 
 #### fn value.new
 
-```ts
+```jsonnet
 new(type, help, default)
 ```
 
 new creates a new object of given type, optionally with description and default value
 
 ### obj T
-
 
 * `T.any` (`string`): `"any"` - argument of type "any"
 * `T.array` (`string`): `"array"` - argument of type "array"
@@ -202,7 +200,7 @@ new creates a new object of given type, optionally with description and default 
 
 #### fn package.new
 
-```ts
+```jsonnet
 new(name, url, help, filename="", version="master")
 ```
 
@@ -219,7 +217,7 @@ Arguments:
 
 #### fn package.newSub
 
-```ts
+```jsonnet
 newSub(name, help)
 ```
 

--- a/doc-util/main.libsonnet
+++ b/doc-util/main.libsonnet
@@ -36,7 +36,10 @@
     new(name, url, help, filename='', version='master')::
       {
         name: name,
-        help: help,
+        help:
+          help
+          + std.get(self, 'installTemplate', '') % self
+          + std.get(self, 'usageTemplate', '') % self,
         'import':
           if filename != ''
           then url + '/' + filename
@@ -70,12 +73,34 @@
         help: help,
       },
 
-    withUsageTemplate(template):: {
-      usageTemplate: template,
+    withInstallTemplate(template):: {
+      installTemplate:
+        if template != null
+        then
+          |||
+
+            ## Install
+
+            ```
+            %s
+            ```
+          ||| % template
+        else '',
     },
 
-    withInstallTemplate(template):: {
-      installTemplate: template,
+    withUsageTemplate(template):: {
+      usageTemplate:
+        if template != null
+        then
+          |||
+
+            ## Usage
+
+            ```jsonnet
+            %s
+            ```
+          ||| % template
+        else '',
     },
   },
 

--- a/doc-util/render.libsonnet
+++ b/doc-util/render.libsonnet
@@ -96,28 +96,6 @@
         + (if std.get(doc, 'help', '') != ''
            then [doc.help]
            else [])
-        + (if 'installTemplate' in doc
-           then [
-             |||
-               ## Install
-
-               ```
-               %(install)s
-               ```
-             ||| % doc.installTemplate % doc,
-           ]
-           else [])
-        + (if 'usageTemplate' in doc
-           then [
-             |||
-               ## Usage
-
-               ```jsonnet
-               %(usage)s
-               ```
-             ||| % doc.usageTemplate % doc,
-           ]
-           else [])
         + (if self.packages.hasPackages()
            then [
              '## Subpackages\n\n'

--- a/doc-util/render.libsonnet
+++ b/doc-util/render.libsonnet
@@ -1,406 +1,418 @@
 {
   local root = self,
 
-  templates: {
-    package: |||
-      # %(name)s
+  render(obj):
+    assert std.isObject(obj) && '#' in obj : 'error: object is not a docsonnet package';
+    local package = self.package(obj);
+    package.toFiles(),
 
-      %(content)s
-    |||,
+  findPackages(obj, path=[]): {
+    local find(obj, path, parentWasPackage=true) =
+      std.foldl(
+        function(acc, k)
+          acc
+          + (
+            // If matches a package, return it
+            if '#' in obj[k]
+            then [root.package(obj[k], path + [k], parentWasPackage)]
+            // If matches a package but warn if also has an object docstring
+            else if '#' in obj[k] && '#' + k in obj
+            then std.trace(
+              'warning: %s both defined as object and package' % k,
+              [root.package(obj[k], path + [k], parentWasPackage)]
+            )
+            // If not, keep looking
+            else find(obj[k], path + [k], parentWasPackage=false)
+          ),
+        std.filter(
+          function(k)
+            !std.startsWith(k, '#')
+            && std.isObject(obj[k]),
+          std.objectFieldsAll(obj)
+        ),
+        []
+      ),
 
-    indexPage: |||
-      # %(prefix)s%(name)s
+    packages: find(obj, path),
 
-      %(index)s
-    |||,
+    hasPackages(): std.length(self.packages) > 0,
 
-    index: |||
-      ## Index
+    toIndex():
+      if self.hasPackages()
+      then
+        std.join('\n', [
+          '* ' + p.link
+          for p in self.packages
+        ])
+        + '\n'
+      else '',
 
-      %s
-    |||,
-
-    sectionTitle: '%(abbr)s %(prefix)s%(name)s',
-
-    sectionLink: '* [`%(abbr)s %(linkName)s`](#%(link)s)',
-
-    value: '* `%(prefix)s%(name)s` (`%(type)s`): `"%(value)s"` - %(help)s',
-
-    section: |||
-      %(headerDepth)s %(title)s
-
-      %(content)s
-    |||,
+    toFiles():
+      std.foldl(
+        function(acc, p)
+          acc
+          + { [p.path]: p.toString() }
+          + p.packages.toFiles(),
+        self.packages,
+        {}
+      ),
   },
 
-  joinPathPrefixes(prefixes, sep='/')::
-    std.join(sep, prefixes)
-    + (if std.length(prefixes) > 0
-       then sep
-       else ''),
+  package(obj, path=[], parentWasPackage=true): {
+    local this = self,
+    local doc = obj['#'],
 
-  joinPrefixes(prefixes, sep='.')::
-    std.join(sep, prefixes)
-    + (if std.length(prefixes) > 0
-       then sep
-       else ''),
+    packages: root.findPackages(obj, path),
+    fields: root.fields(obj),
 
-  renderSectionTitle(section, prefixes)::
-    root.templates.sectionTitle % {
-      name: section.name,
-      abbr: section.type.abbr,
-      prefix: root.joinPrefixes(prefixes),
-    },
-
-  renderValues(values, prefixes=[])::
-    if std.length(values) > 0
-    then
-      std.join('\n', [
-        root.templates.value
-        % value {
-          prefix: root.joinPrefixes(prefixes),
-        }
-        for value in values
-      ]) + '\n'
-    else '',
-
-  renderSections(sections, depth=0, prefixes=[])::
-    if std.length(sections) > 0
-    then
-      std.join('\n', [
-        root.templates.section
-        % {
-          headerDepth: std.join('', [
-            '#'
-            for d in std.range(0, depth + 2)
-          ]),
-          title: root.renderSectionTitle(
-            section,
-            prefixes,
-          ),
-          content: section.content,
-        }
-        + root.renderValues(
-          section.values,
-          prefixes + [section.name]
-        )
-        + root.renderSections(
-          section.subSections,
-          depth + 1,
-          prefixes + [section.name]
-        )
-        for section in sections
-      ])
-    else '',
-
-  renderPackage(package, path='')::
-    (root.templates.package % package)
-    + (
-      if std.length(package.subPackages) > 0
-      then
-        '## Subpackages\n\n'
-        + std.join('\n', [
-          '* [%(name)s](%(path)s)' % {
-            name: sub.name,
-            path: path + sub.name
-                  + (if std.length(sub.subPackages) > 0
-                     then '/index.md'
-                     else '.md'),
-          }
-          for sub in package.subPackages
-        ]) + '\n\n'
-      else ''
-    )
-    + (if std.length(package.sections) > 0
-       then (root.templates.index % root.index(package.sections))
-       else '')
-    + (if std.length(package.values) > 0
-          || std.length(package.sections) > 0
-       then
-         '\n## Fields\n\n'
-         + root.renderValues(package.values)
-         + root.renderSections(package.sections)
-       else ''),
-
-  index(sections, depth=0, prefixes=[])::
-    std.join('\n', [
-      std.join('', [
-        ' '
-        for d in std.range(0, (depth * 2) - 1)
-      ])
-      + (root.templates.sectionLink % {
-           abbr: section.type.abbr,
-           linkName: section.linkName,
-           link:
-             std.asciiLower(
-               std.strReplace(
-                 std.strReplace(root.renderSectionTitle(section, prefixes), '.', '')
-                 , ' ', '-'
-               )
-             ),
-         })
-      + (
-        if std.length(section.subSections) > 0
-        then '\n' + root.index(
-          section.subSections,
-          depth + 1,
-          prefixes + [section.name]
-        )
-        else ''
+    path:
+      std.join(
+        '/',
+        path
       )
-      for section in sections
+      + (if self.packages.hasPackages()
+         then '/index.md'
+         else '.md'),
+
+    link:
+      '[%s](%s)' % [
+        std.join(
+          '.',
+          (if parentWasPackage  // if parent object was a package
+           then path[1:]  // then strip first item from path
+           else path)
+        ),
+        self.path,
+      ],
+
+    toFiles():
+      { 'README.md': this.toString() }
+      + self.packages.toFiles(),
+
+    toString():
+      std.join(
+        '\n',
+        ['# ' + doc.name + '\n']
+        + (if std.get(doc, 'help', '') != ''
+           then [doc.help]
+           else [])
+        + (if 'installTemplate' in doc
+           then [
+             |||
+               ## Install
+
+               ```
+               %(install)s
+               ```
+             ||| % doc.installTemplate % doc,
+           ]
+           else [])
+        + (if 'usageTemplate' in doc
+           then [
+             |||
+               ## Usage
+
+               ```jsonnet
+               %(usage)s
+               ```
+             ||| % doc.usageTemplate % doc,
+           ]
+           else [])
+        + (if self.packages.hasPackages()
+           then [
+             '## Subpackages\n\n'
+             + self.packages.toIndex(),
+           ]
+           else [])
+        + (if self.fields.hasFields()
+           then [
+             '## Index\n\n'
+             + self.fields.toIndex()
+             + '\n## Fields\n'
+             + self.fields.toString(),
+           ]
+           else [])
+      ),
+  },
+
+  fields(obj, path=[]): {
+    values: root.findValues(obj, path),
+    functions: root.findFunctions(obj, path),
+    objects: root.findObjects(obj, path),
+
+    hasFields():
+      std.any([
+        self.values.hasFields(),
+        self.functions.hasFields(),
+        self.objects.hasFields(),
+      ]),
+
+    toIndex():
+      std.join('', [
+        self.functions.toIndex(),
+        self.objects.toIndex(),
+      ]),
+
+    toString():
+      std.join('', [
+        self.values.toString(),
+        self.functions.toString(),
+        self.objects.toString(),
+      ]),
+  },
+
+  findObjects(obj, path=[]): {
+    local keys =
+      std.filter(
+        root.util.filter('object', obj),
+        std.objectFieldsAll(obj)
+      ),
+
+    local undocumentedKeys =
+      std.filter(
+        function(k)
+          std.all([
+            !std.startsWith(k, '#'),
+            std.isObject(obj[k]),
+            !('#' + k in obj),  // not documented in parent
+            !('#' in obj[k]),  // not a sub package
+          ]),
+        std.objectFieldsAll(obj)
+      ),
+
+    objects:
+      std.foldl(
+        function(acc, k)
+          acc + [
+            root.obj(
+              root.util.realkey(k),
+              obj[k],
+              obj[root.util.realkey(k)],
+              path,
+            ),
+          ],
+        keys,
+        []
+      )
+      + std.foldl(
+        function(acc, k)
+          local o = root.obj(
+            k,
+            { object: { help: '' } },
+            obj[k],
+            path,
+          );
+          acc
+          + (if o.fields.hasFields()
+             then [o]
+             else []),
+        undocumentedKeys,
+        []
+      ),
+
+    hasFields(): std.length(self.objects) > 0,
+
+    toIndex():
+      if self.hasFields()
+      then
+        std.join('', [
+          std.join(
+            '',
+            [' ' for d in std.range(0, (std.length(path) * 2) - 1)]
+            + ['* ', f.link]
+            + ['\n']
+            + (if f.fields.hasFields()
+               then [f.fields.toIndex()]
+               else [])
+          )
+          for f in self.objects
+        ])
+      else '',
+
+    toString():
+      if self.hasFields()
+      then
+        std.join('', [
+          o.toString()
+          for o in self.objects
+        ])
+      else '',
+  },
+
+  obj(name, doc, obj, path): {
+    fields: root.fields(obj, path + [name]),
+
+    path: std.join('.', path + [name]),
+    fragment: root.util.fragment(std.join('', path + [name])),
+    link: '[`obj %s`](#obj-%s)' % [name, self.fragment],
+
+    toString():
+      std.join(
+        '\n',
+        [root.util.title('obj ' + self.path, std.length(path) + 2)]
+        + (if doc.object.help != ''
+           then [doc.object.help]
+           else [])
+        + [self.fields.toString()]
+      ),
+  },
+
+  findFunctions(obj, path=[]): {
+    local keys =
+      std.filter(
+        root.util.filter('function', obj),
+        std.objectFieldsAll(obj)
+      ),
+
+    functions:
+      std.foldl(
+        function(acc, k)
+          acc + [
+            root.func(
+              root.util.realkey(k),
+              obj[k],
+              path,
+            ),
+          ],
+        keys,
+        []
+      ),
+
+    hasFields(): std.length(self.functions) > 0,
+
+    toIndex():
+      if self.hasFields()
+      then
+        std.join('', [
+          std.join(
+            '',
+            [' ' for d in std.range(0, (std.length(path) * 2) - 1)]
+            + ['* ', f.link]
+            + ['\n']
+          )
+          for f in self.functions
+        ])
+      else '',
+
+    toString():
+      if self.hasFields()
+      then
+        std.join('', [
+          f.toString()
+          for f in self.functions
+        ])
+      else '',
+  },
+
+  func(name, doc, path): {
+    path: std.join('.', path + [name]),
+    fragment: root.util.fragment(std.join('', path + [name])),
+    link: '[`fn %s(%s)`](#fn-%s)' % [name, self.args, self.fragment],
+
+    args: std.join(', ', [
+      if arg.default != null
+      then std.join('=', [
+        arg.name,
+        std.manifestJsonEx(arg.default, '', ''),
+      ])
+      else arg.name
+      for arg in doc['function'].args
     ]),
 
-  sections: {
-    base: {
-      subSections: [],
-      values: [],
-    },
-    object(key, doc, obj, depth):: self.base {
-      name: std.strReplace(key, '#', ''),
+    enums: std.join('', [
+      if arg.enums != null
+      then '\n\nAccepted values for `%s` are ' % arg.name
+           + std.join(', ', [
+             std.manifestJsonEx(item, '', '')
+             for item in arg.enums
+           ])
+      else ''
+      for arg in doc['function'].args
+    ]),
 
-      local processed = root.prepare(obj, depth=depth + 1),
-
-      subPackages: std.get(processed, 'subPackages', []),
-
-      subSections: processed.sections,
-
-      values: processed.values,
-
-      type: { full: 'object', abbr: 'obj' },
-
-      abbr: self.type.abbr,
-
-      doc:
-        if self.type.full in doc
-        then doc[self.type.full]
-        else { help: '' },
-
-      help: self.doc.help,
-
-      linkName: self.name,
-
-      content:
-        if self.help != ''
-        then self.help + '\n'
-        else '',
-    },
-
-    'function'(key, doc):: self.base {
-      name: std.strReplace(key, '#', ''),
-
-      type: { full: 'function', abbr: 'fn' },
-
-      abbr: self.type.abbr,
-
-      doc: doc[self.type.full],
-
-      help: self.doc.help,
-
-      args: std.join(', ', [
-        if arg.default != null
-        then std.join('=', [
-          arg.name,
-          std.manifestJsonEx(arg.default, '', ''),
-        ])
-        else arg.name
-        for arg in self.doc.args
-      ]),
-
-      enums: std.join('', [
-        if arg.enums != null
-        then '\n\nAccepted values for `%s` are ' % arg.name
-             + std.join(', ', [
-               std.manifestJsonEx(item, '', '')
-               for item in arg.enums
-             ])
-        else ''
-        for arg in self.doc.args
-      ]),
-
-      linkName: '%(name)s(%(args)s)' % self,
-
-      content:
-        (|||
-           ```ts
-           %(name)s(%(args)s)
-           ```
-
-         ||| % self)
-        + '%(help)s' % self
-        + '%(enums)s' % self,
-      // odd concatenation to prevent unintential newline changes
-
-    },
-
-    value(key, doc, obj):: self.base {
-      name: std.strReplace(key, '#', ''),
-      type: doc.value.type,
-      help: doc.value.help,
-      value: obj,
-    },
-
-    package(doc, root):: {
-      name: doc.name,
-      content:
+    toString():
+      std.join('\n', [
+        root.util.title('fn ' + self.path, std.length(path) + 2),
         |||
-          %(help)s
-        ||| % doc
-        + (if 'installTemplate' in doc
-           then |||
-
-             ## Install
-
-             ```
-             %(install)s
-             ```
-           ||| % doc.installTemplate % doc
-           else '')
-        + (if 'usageTemplate' in doc
-           then |||
-
-             ## Usage
-
-             ```jsonnet
-             %(usage)s
-             ```
-           ||| % doc.usageTemplate % doc
-           else ''),
-    },
+          ```jsonnet
+          %(name)s(%(args)s)
+          ```
+        ||| % [name, self.args],
+        doc['function'].help,
+        self.enums,
+      ]),
   },
 
-  prepare(obj, depth=0)::
-    std.foldl(
-      function(acc, key)
-        acc +
-        // Package definition
-        if key == '#'
-        then root.sections.package(
-          obj[key],
-          (depth == 0)
-        )
+  findValues(obj, path=[]): {
+    local keys =
+      std.filter(
+        root.util.filter('value', obj),
+        std.objectFieldsAll(obj)
+      ),
 
+    values:
+      std.foldl(
+        function(acc, k)
+          acc + [
+            root.val(
+              root.util.realkey(k),
+              obj[k],
+              obj[root.util.realkey(k)],
+              path,
+            ),
+          ],
+        keys,
+        []
+      ),
 
-        // Field definition
-        else if std.startsWith(key, '#')
-        then (
-          local realKey = key[1:];
+    hasFields(): std.length(self.values) > 0,
 
-          if !std.isObject(obj[key])
-          then
-            std.trace(
-              'INFO: docstring "%s" cannot be parsed, ignored while rendering.' % key,
-              {}
-            )
+    toString():
+      if self.hasFields()
+      then
+        std.join('\n', [
+          '* ' + f.toString()
+          for f in self.values
+        ]) + '\n'
+      else '',
+  },
 
-          else if 'value' in obj[key]
-          then {
-            values+: [root.sections.value(
-              key,
-              obj[key],
-              obj[realKey]
-            )],
-          }
-          else if 'function' in obj[key]
-          then {
-            functionSections+: [root.sections['function'](
-              key,
-              obj[key],
-            )],
-          }
-          else if 'object' in obj[key]
-          then {
-            objectSections+: [root.sections.object(
-              key,
-              obj[key],
-              obj[realKey],
-              depth
-            )],
-          }
-          else
-            std.trace(
-              'INFO: docstring "%s" cannot be parsed, ignored while rendering.' % key,
-              {}
-            )
-        )
-
-        // subPackage definition
-        else if std.isObject(obj[key]) && '#' in obj[key]
-        then {
-          subPackages+: [root.prepare(obj[key])],
-        }
-
-        // undocumented object
-        else if std.isObject(obj[key]) && !('#' + key in obj)
-        then (
-          local section = root.sections.object(
-            key,
-            {},
-            obj[key],
-            depth
-          );
-          // only add if has documented subSections or values
-          if std.length(section.subSections) > 0
-             || std.length(section.values) > 0
-          then {
-            objectSections+: [section],
-            subPackages+: section.subPackages,
-          }
-          else {}
-        )
-
-        else {},
-      std.objectFieldsAll(obj),
-      {
-        functionSections: [],
-        objectSections: [],
-
-        sections:
-          self.functionSections
-          + self.objectSections,
-        subPackages: [],
-        values: [],
-      }
-    ),
-
-  renderIndexPage(package, prefixes)::
-    root.templates.indexPage % {
-      name: package.name,
-      prefix: root.joinPrefixes(prefixes),
-      index: std.join('\n', [
-        '* [%(name)s](%(name)s.md)' % sub
-        for sub in package.subPackages
+  val(name, doc, obj, path): {
+    toString():
+      std.join(' ', [
+        '`%s`' % std.join('.', path + [name]),
+        '(`%s`):' % doc.value.type,
+        '`"%s"`' % obj,
+        '-',
+        doc.value.help,
       ]),
-    },
+  },
 
-  renderFiles(package, prefixes=[]):
-    local path = root.joinPathPrefixes(prefixes);
-    (
-      if std.length(prefixes) == 0
-      then {
-        [path + 'README.md']: root.renderPackage(package, package.name + '/'),
-      }
-      else if std.length(package.subPackages) > 0
-      then {
-        [path + package.name + '/index.md']: root.renderPackage(package),
-      }
-      else {
-        [path + package.name + '.md']: root.renderPackage(package, package.name + '/'),
-      }
-    )
-    + std.foldl(
-      function(acc, sub)
-        acc + sub,
-      [
-        root.renderFiles(
-          sub,
-          prefixes=prefixes + [package.name]
+  util: {
+    realkey(key):
+      assert std.startsWith(key, '#') : 'Key %s not a docstring key' % key;
+      key[1:],
+    title(title, depth=0):
+      std.join(
+        '',
+        ['\n']
+        + ['#' for i in std.range(0, depth)]
+        + [' ', title, '\n']
+      ),
+    fragment(title):
+      std.asciiLower(
+        std.strReplace(
+          std.strReplace(title, '.', '')
+          , ' ', '-'
         )
-        for sub in package.subPackages
-      ],
-      {}
-    ),
-
-  render(obj):
-    self.renderFiles(self.prepare(obj)),
+      ),
+    filter(type, obj):
+      function(k)
+        std.all([
+          std.startsWith(k, '#'),
+          std.isObject(obj[k]),
+          type in obj[k],
+          root.util.realkey(k) in obj,
+        ]),
+  },
 }


### PR DESCRIPTION
In #52 an attempt was made to surface the subpackages that are layered a bit deeper into an object, turns out this was insufficient. When two separate subpackages had the same name, then they would overwrite the file as the difference in json path was not reflected in the file path.

In an attempt to fix that I gave up on the existing render engine, it was the first implementation of that and I never really felt comfortable with it. Soooo, I started from scratch. This render engine is a bit more layered, starting from a docsonnet package and expanding that with it's contents, I hope the code is a bit easier to follow.

The subpackage directory layout might render a tad bit different, not including the package name, this was one of the problems that made it hard to fix #52. Theoratically this can be seen as a "breaking change" or at least needing manual intervention in some cases.

For review:
- Don't try to diff, the code is vastly different.
- As the render of the README shows, I've updated the code examples to say it is `jsonnet` rather than `ts`.
- Also newlines are hard to do right, I think I've covered most issues with it to reduce the diff size. :shrug:

Hint for reading diffs: 
```
git diff --ignore-matching-lines='```(ts|jsonnet)' --ignore-blank-lines
```