### PR TITLE
feat(render): add ability to igore a docstring while rendering

### DIFF
--- a/doc-util/render.libsonnet
+++ b/doc-util/render.libsonnet
@@ -27,7 +27,8 @@
         std.filter(
           function(k)
             !std.startsWith(k, '#')
-            && std.isObject(obj[k]),
+            && std.isObject(obj[k])
+            && !std.objectHasAll(obj[k], 'ignore'),
           std.objectFieldsAll(obj)
         ),
         []
@@ -150,6 +151,7 @@
           std.all([
             !std.startsWith(k, '#'),
             std.isObject(obj[k]),
+            !std.objectHasAll(obj[k], 'ignore'),
             !('#' + k in obj),  // not documented in parent
             !('#' in obj[k]),  // not a sub package
           ]),
@@ -390,6 +392,7 @@
         std.all([
           std.startsWith(k, '#'),
           std.isObject(obj[k]),
+          !std.objectHasAll(obj[k], 'ignore'),
           type in obj[k],
           root.util.realkey(k) in obj,
         ]),

--- a/doc-util/render.libsonnet
+++ b/doc-util/render.libsonnet
@@ -14,12 +14,14 @@
           + (
             // If matches a package but warn if also has an object docstring
             if '#' in obj[k] && '#' + k in obj
+               && !std.objectHasAll(obj[k]['#'], 'ignore')
             then std.trace(
               'warning: %s both defined as object and package' % k,
               [root.package(obj[k], path + [k], parentWasPackage)]
             )
             // If matches a package, return it
             else if '#' in obj[k]
+                    && !std.objectHasAll(obj[k]['#'], 'ignore')
             then [root.package(obj[k], path + [k], parentWasPackage)]
             // If not, keep looking
             else find(obj[k], path + [k], parentWasPackage=false)
@@ -27,8 +29,7 @@
         std.filter(
           function(k)
             !std.startsWith(k, '#')
-            && std.isObject(obj[k])
-            && !std.objectHasAll(obj[k], 'ignore'),
+            && std.isObject(obj[k]),
           std.objectFieldsAll(obj)
         ),
         []


### PR DESCRIPTION
When deprecating code paths I want to provide a backwards compatible endpoint by linking back to it, however I want to exclude that from the docs. This parameter allows me to ignore those docstrings when rendering.